### PR TITLE
Have CI use newer versions of ruby and use supported bundler version

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -18,13 +18,10 @@ permissions:
 
 jobs:
   test:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     strategy:
       matrix:
         ruby-version: 
-        - '2.0'
-        - '2.1'
-        - '2.2'
         - '2.3'
         - '2.4'
         - '2.5'
@@ -32,9 +29,11 @@ jobs:
         - '2.7'
         - '3.0'
         - '3.1'
+        - '3.4'
         - jruby-9.1.17.0
         - jruby-9.2.21.0
         - jruby-9.3.6.0
+        - jruby-9.4.9.0
 
     steps:
     - uses: actions/checkout@v3


### PR DESCRIPTION
The CI runner at github was failing on the older ruby versions:

    Bundler 2 requires Ruby 2.3+, using Bundler 1 on Ruby <= 2.2
    /opt/hostedtoolcache/Ruby/2.2.10/x64/bin/gem install bundler -v ~> 1.0
    ERROR:  While executing gem ... (RuntimeError)

It was also failing to find the images:

Error: Unavailable version 9.2.21.0 for jruby on ubuntu-24.04 You can request it at https://github.com/ruby/setup-ruby/issues Cause: Unexpected HTTP response: 404 at /home/runner/work/_actions/ruby/setup-ruby/v1/dist/index.js:71342:15 at process.processTicksAndRejections (node:internal/process/task_queues:95:5) at async body (/home/runner/work/_actions/ruby/setup-ruby/v1/dist/index.js:355:14) test (jruby-9.3.6.0)

Error: Unavailable version 9.3.6.0 for jruby on ubuntu-24.04 You can request it at https://github.com/ruby/setup-ruby/issues Cause: Unexpected HTTP response: 404 at /home/runner/work/_actions/ruby/setup-ruby/v1/dist/index.js:71342:15 at process.processTicksAndRejections (node:internal/process/task_queues:95:5) at async body (/home/runner/work/_actions/ruby/setup-ruby/v1/dist/index.js:355:14)

Error: Unavailable version 9.1.17.0 for jruby on ubuntu-24.04 You can request it at https://github.com/ruby/setup-ruby/issues Cause: Unexpected HTTP response: 404 at /home/runner/work/_actions/ruby/setup-ruby/v1/dist/index.js:71342:15 at process.processTicksAndRejections (node:internal/process/task_queues:95:5) at async body (/home/runner/work/_actions/ruby/setup-ruby/v1/dist/index.js:355:14)